### PR TITLE
feat!: replace --first-party-prefix with repeatable --group

### DIFF
--- a/.config/prek.toml
+++ b/.config/prek.toml
@@ -15,7 +15,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/biomejs/pre-commit"
-rev = "v2.4.13"
+rev = "v2.5.2"
 hooks = [
     {
         id = "biome-check",
@@ -28,7 +28,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/tombi-toml/tombi-pre-commit"
-rev = "v0.9.21"
+rev = "v1.1.7"
 hooks = [
     {
         id = "tombi-format",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.24']
+        go-version: ['1.26']
 
     steps:
       - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.gitignore
+++ b/.gitignore
@@ -193,5 +193,4 @@ tags
 # Added by goreleaser init:
 dist/
 
-qmlimportsort
-!cmd/
+/qmlimportsort

--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,8 @@ alias fmt := format
     just --list --unsorted
 
 init:
-    go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
-    go install github.com/securego/gosec/v2/cmd/gosec@v2.22.10
+    go install honnef.co/go/tools/cmd/staticcheck@2026.1
+    go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
 
 format:
     uv run prek --config .config/prek.toml run --all-files
@@ -27,11 +27,11 @@ lint:
 
 # Run all tests
 [group('dev')]
-@test *FLAGS:
+test *FLAGS:
     go clean -testcache
     go test ./... {{ FLAGS }}
 
 # Build the qmlimportsort binary
 [group('build')]
-@build:
+build:
     go build -o qmlimportsort ./cmd/qmlimportsort

--- a/README.MD
+++ b/README.MD
@@ -23,6 +23,7 @@ Imports are grouped into pragmas, Qt, default, custom sections (opt-in), and rel
 
 Given this file:
 
+<!-- test:input -->
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -43,6 +44,7 @@ Item {}
 
 `qmlimportsort Main.qml` applies the default grouping — everything that is not Qt or relative shares one section:
 
+<!-- test:expect -->
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -66,6 +68,7 @@ Item {}
 
 `qmlimportsort --group MyApp. Main.qml` gives the project's own modules their own section:
 
+<!-- test:expect -->
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -90,6 +93,7 @@ Item {}
 
 `qmlimportsort --group Company. --group MyApp. Main.qml` splits further — one section per namespace, in flag order:
 
+<!-- test:expect -->
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //

--- a/README.MD
+++ b/README.MD
@@ -19,41 +19,98 @@ A tool to organize and sort QML import statements.
 
 ## Example
 
-Imports are grouped into pragmas, Qt, third-party, first-party (opt-in), and relative — sorted and de-duplicated within each group, separated by a blank line.
+Imports are grouped into pragmas, Qt, default, custom sections (opt-in), and relative — sorted and de-duplicated within each group, separated by a blank line.
 
-Before:
+Given this file:
 
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
 // SPDX-License-Identifier: MIT
-import "../components"
-import MyModule
 import QtQuick.Controls
+import "../components"
+import MyApp.Views
 import org.kde.kirigami as Kirigami
 import QtQuick
-pragma Singleton
-QtObject {}
+import Company.Widgets 1.2
+import MyApp.Backend
+import QtQuick
+pragma ComponentBehavior: Bound
+import Qt.labs.settings
+
+Item {}
 ```
 
-After:
+`qmlimportsort Main.qml` applies the default grouping — everything that is not Qt or relative shares one section:
 
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
 // SPDX-License-Identifier: MIT
 
-pragma Singleton
+pragma ComponentBehavior: Bound
 
+import Qt.labs.settings
 import QtQuick
 import QtQuick.Controls
 
-import MyModule
+import Company.Widgets 1.2
+import MyApp.Backend
+import MyApp.Views
 import org.kde.kirigami as Kirigami
 
 import "../components"
 
-QtObject {}
+Item {}
+```
+
+`qmlimportsort --group MyApp. Main.qml` gives the project's own modules their own section:
+
+```qml
+// SPDX-FileCopyrightText: Jane Doe
+//
+// SPDX-License-Identifier: MIT
+
+pragma ComponentBehavior: Bound
+
+import Qt.labs.settings
+import QtQuick
+import QtQuick.Controls
+
+import Company.Widgets 1.2
+import org.kde.kirigami as Kirigami
+
+import MyApp.Backend
+import MyApp.Views
+
+import "../components"
+
+Item {}
+```
+
+`qmlimportsort --group Company. --group MyApp. Main.qml` splits further — one section per namespace, in flag order:
+
+```qml
+// SPDX-FileCopyrightText: Jane Doe
+//
+// SPDX-License-Identifier: MIT
+
+pragma ComponentBehavior: Bound
+
+import Qt.labs.settings
+import QtQuick
+import QtQuick.Controls
+
+import org.kde.kirigami as Kirigami
+
+import Company.Widgets 1.2
+
+import MyApp.Backend
+import MyApp.Views
+
+import "../components"
+
+Item {}
 ```
 
 ## Usage
@@ -72,8 +129,8 @@ qmlimportsort --stdout Main.qml
 # Pipe through stdin/stdout
 cat Main.qml | qmlimportsort --stdin
 
-# Mark imports owned by your project as first-party (repeatable)
-qmlimportsort --first-party-prefix=io.github.mpvqc. src/
+# Give your project's modules their own section (repeatable, comma-separated)
+qmlimportsort --group io.github.mpvqc. src/
 ```
 
 Run `qmlimportsort --help` for the full flag list.

--- a/README.MD
+++ b/README.MD
@@ -146,7 +146,7 @@ Item {}
 
 ## Development
 
-Requires Go 1.24+.
+Requires Go 1.26+.
 
 ```shell
 just build

--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,28 @@ A tool to organize and sort QML import statements.
 > [!NOTE]
 > Comments between two imports are hoisted into a single comment section above the imports — they do not travel with their original import line through sorting. To attach a note to a specific import, put it as a trailing comment on the same line (e.g. `import QtQuick // note`).
 
+## Usage
+
+```shell
+# Format files or directories in place
+qmlimportsort Main.qml
+qmlimportsort src/
+
+# Dry run — print paths that would change, exit 1 if any
+qmlimportsort --check src/
+
+# Print formatted content to stdout, leave file untouched
+qmlimportsort --stdout Main.qml
+
+# Pipe through stdin/stdout
+cat Main.qml | qmlimportsort --stdin
+
+# Give your project's modules their own section (repeatable, comma-separated)
+qmlimportsort --group io.github.mpvqc. src/
+```
+
+Run `qmlimportsort --help` for the full flag list.
+
 ## Examples
 
 Imports are grouped into pragmas, Qt, default, custom sections (opt-in), and relative — sorted and de-duplicated within each group, separated by a blank line.
@@ -25,6 +47,7 @@ Imports are grouped into pragmas, Qt, default, custom sections (opt-in), and rel
 Given this file:
 
 <!-- test:input -->
+
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -46,6 +69,7 @@ Item {}
 `qmlimportsort Main.qml` applies the default grouping — everything that is not Qt or relative shares one section:
 
 <!-- test:expect -->
+
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -70,6 +94,7 @@ Item {}
 `qmlimportsort --group MyApp. Main.qml` gives the project's own modules their own section:
 
 <!-- test:expect -->
+
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -95,6 +120,7 @@ Item {}
 `qmlimportsort --group Company. --group MyApp. Main.qml` splits further — one section per namespace, in flag order:
 
 <!-- test:expect -->
+
 ```qml
 // SPDX-FileCopyrightText: Jane Doe
 //
@@ -117,28 +143,6 @@ import "../components"
 
 Item {}
 ```
-
-## Usage
-
-```shell
-# Format files or directories in place
-qmlimportsort Main.qml
-qmlimportsort src/
-
-# Dry run — print paths that would change, exit 1 if any
-qmlimportsort --check src/
-
-# Print formatted content to stdout, leave file untouched
-qmlimportsort --stdout Main.qml
-
-# Pipe through stdin/stdout
-cat Main.qml | qmlimportsort --stdin
-
-# Give your project's modules their own section (repeatable, comma-separated)
-qmlimportsort --group io.github.mpvqc. src/
-```
-
-Run `qmlimportsort --help` for the full flag list.
 
 ## Development
 

--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,7 @@ A tool to organize and sort QML import statements.
 
 > [!CAUTION]
 > This tool is in early development. Use at your own risk.
+> The CLI is not stable yet — flags and behavior may change in breaking ways until version 1.0.0.
 
 > [!IMPORTANT]
 > This is a vibe-coded project — most of the code was written collaboratively with an AI assistant.
@@ -17,7 +18,7 @@ A tool to organize and sort QML import statements.
 > [!NOTE]
 > Comments between two imports are hoisted into a single comment section above the imports — they do not travel with their original import line through sorting. To attach a note to a specific import, put it as a trailing comment on the same line (e.g. `import QtQuick // note`).
 
-## Example
+## Examples
 
 Imports are grouped into pragmas, Qt, default, custom sections (opt-in), and relative — sorted and de-duplicated within each group, separated by a blank line.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,5 +8,5 @@ SPDX-License-Identifier: MIT
 
 ## Refactor
 
-1. **Design the CLI** — ✅ Done. Agreed surface: write-by-default, `--check` / `--stdout` / `--stdin` modes, recursive directory walking, skip dotfiles, atomic writes. Full spec in [docs/devel/CLI.md](docs/devel/CLI.md).
+1. **Design the CLI** — ✅ Done. Agreed surface: write-by-default, `--check` / `--stdout` / `--stdin` modes, recursive directory walking, skip dotfiles, atomic writes. Contracts in [docs/devel/CLI.md](docs/devel/CLI.md); the flag surface lives in `--help`.
 2. **Design the internal API** — ✅ Done. Split into `internal/qml` (pure `Format([]byte)`) and `internal/fs` (I/O shell: walker, atomic writes, stream/file helpers). `main` is a thin dispatcher. Full spec in [docs/devel/INTERNAL_API.md](docs/devel/INTERNAL_API.md).

--- a/cmd/qmlimportsort/main.go
+++ b/cmd/qmlimportsort/main.go
@@ -32,8 +32,10 @@ FLAGS:
                             Single file only.
    --stdin                  Read from stdin, write to stdout. Mutually
                             exclusive with positional paths.
-   --first-party-prefix     Prefix that marks a non-Qt, non-relative
-                            import as first-party. Repeatable.
+   --group                  Comma-separated prefixes forming one custom
+                            import section. Repeatable; sections appear
+                            between the default and relative sections
+                            in flag order.
    --version                Print version, exit 0.
    --help, -h               Print this help, exit 0.
 `
@@ -55,13 +57,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	var (
 		check, stdoutMode, stdinMode bool
 		showVersion, showHelp, showH bool
-		prefixes                     stringList
+		groupFlags                   stringList
 	)
 	flags.BoolVar(&check, "check", false, "")
 	flags.BoolVar(&check, "c", false, "")
 	flags.BoolVar(&stdoutMode, "stdout", false, "")
 	flags.BoolVar(&stdinMode, "stdin", false, "")
-	flags.Var(&prefixes, "first-party-prefix", "")
+	flags.Var(&groupFlags, "group", "")
 	flags.BoolVar(&showVersion, "version", false, "")
 	flags.BoolVar(&showHelp, "help", false, "")
 	flags.BoolVar(&showH, "h", false, "")
@@ -94,7 +96,11 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	classifier, err := qml.Compile(qml.Options{FirstPartyPrefixes: prefixes})
+	groups := make([][]string, 0, len(groupFlags))
+	for _, g := range groupFlags {
+		groups = append(groups, strings.Split(g, ","))
+	}
+	classifier, err := qml.Compile(qml.Options{Groups: groups})
 	if err != nil {
 		reportErr(stderr, err)
 		return 2

--- a/cmd/qmlimportsort/main.go
+++ b/cmd/qmlimportsort/main.go
@@ -98,7 +98,14 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 
 	groups := make([][]string, 0, len(groupFlags))
 	for _, g := range groupFlags {
-		groups = append(groups, strings.Split(g, ","))
+		prefixes := strings.Split(g, ",")
+		for _, p := range prefixes {
+			if strings.TrimSpace(p) == "" {
+				reportErr(stderr, fmt.Errorf("--group %q: empty prefix (stray comma?)", g))
+				return 2
+			}
+		}
+		groups = append(groups, prefixes)
 	}
 	classifier, err := qml.Compile(qml.Options{Groups: groups})
 	if err != nil {

--- a/cmd/qmlimportsort/main_test.go
+++ b/cmd/qmlimportsort/main_test.go
@@ -16,6 +16,9 @@ import (
 const (
 	unformatted = "import QtQuick\nimport QtQml\n\nRectangle {}\n"
 	formatted   = "import QtQml\nimport QtQuick\n\nRectangle {}\n"
+
+	groupInput     = "import QtQuick\nimport com.acme.widgets\nimport io.github.someone\n\nRectangle {}\n"
+	groupFormatted = "import QtQuick\n\nimport io.github.someone\n\nimport com.acme.widgets\n\nRectangle {}\n"
 )
 
 func writeFile(t *testing.T, path, content string) {
@@ -253,14 +256,64 @@ func TestGroupEmptyPrefixNamesFlagValue(t *testing.T) {
 }
 
 func TestGroupIsApplied(t *testing.T) {
-	in := "import QtQuick\nimport com.acme.widgets\nimport io.github.someone\n\nRectangle {}\n"
-	want := "import QtQuick\n\nimport io.github.someone\n\nimport com.acme.widgets\n\nRectangle {}\n"
-	r := runCmd(t, []string{"--group=com.acme.", "--stdin"}, in)
+	r := runCmd(t, []string{"--group=com.acme.", "--stdin"}, groupInput)
 	if r.code != 0 {
 		t.Errorf("code = %d, want 0; stderr=%q", r.code, r.stderr)
 	}
-	if r.stdout != want {
-		t.Errorf("stdout =\n%q\nwant\n%q", r.stdout, want)
+	if r.stdout != groupFormatted {
+		t.Errorf("stdout =\n%q\nwant\n%q", r.stdout, groupFormatted)
+	}
+}
+
+func TestGroupAppliesToDirectoryWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "a.qml")
+	writeFile(t, path, groupInput)
+
+	r := runCmd(t, []string{"--group=com.acme.", dir}, "")
+	if r.code != 1 {
+		t.Errorf("code = %d, want 1; stderr=%q", r.code, r.stderr)
+	}
+	if got := readFile(t, path); got != groupFormatted {
+		t.Errorf("file = %q, want %q", got, groupFormatted)
+	}
+}
+
+func TestGroupAppliesToCheckMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.qml")
+	defaultClean := "import QtQuick\n\nimport com.acme.widgets\nimport io.github.someone\n\nRectangle {}\n"
+	writeFile(t, path, defaultClean)
+
+	if r := runCmd(t, []string{"--check", path}, ""); r.code != 0 {
+		t.Errorf("without --group: code = %d, want 0; stderr=%q", r.code, r.stderr)
+	}
+	r := runCmd(t, []string{"--check", "--group=com.acme.", path}, "")
+	if r.code != 1 {
+		t.Errorf("with --group: code = %d, want 1; stderr=%q", r.code, r.stderr)
+	}
+	if !strings.Contains(r.stdout, path) {
+		t.Errorf("stdout should list %s; got %q", path, r.stdout)
+	}
+	if got := readFile(t, path); got != defaultClean {
+		t.Errorf("--check modified file: %q", got)
+	}
+}
+
+func TestGroupAppliesToStdoutMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.qml")
+	writeFile(t, path, groupInput)
+
+	r := runCmd(t, []string{"--stdout", "--group=com.acme.", path}, "")
+	if r.code != 0 {
+		t.Errorf("code = %d, want 0; stderr=%q", r.code, r.stderr)
+	}
+	if r.stdout != groupFormatted {
+		t.Errorf("stdout =\n%q\nwant\n%q", r.stdout, groupFormatted)
+	}
+	if got := readFile(t, path); got != groupInput {
+		t.Errorf("--stdout modified file: %q", got)
 	}
 }
 

--- a/cmd/qmlimportsort/main_test.go
+++ b/cmd/qmlimportsort/main_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -236,6 +237,18 @@ func TestBadGroupPrefixExit2(t *testing.T) {
 	}
 	if !strings.Contains(r.stderr, "QtFoo") {
 		t.Errorf("stderr should name offending prefix; got %q", r.stderr)
+	}
+}
+
+func TestGroupEmptyPrefixNamesFlagValue(t *testing.T) {
+	for _, value := range []string{"", ",", "MyApp.,", "a,,b", "   "} {
+		r := runCmd(t, []string{"--group=" + value, "--stdin"}, formatted)
+		if r.code != 2 {
+			t.Errorf("--group=%q: code = %d, want 2", value, r.code)
+		}
+		if !strings.Contains(r.stderr, fmt.Sprintf("%q", value)) {
+			t.Errorf("--group=%q: stderr should name the flag value; got %q", value, r.stderr)
+		}
 	}
 }
 

--- a/cmd/qmlimportsort/main_test.go
+++ b/cmd/qmlimportsort/main_test.go
@@ -229,8 +229,8 @@ func TestMissingPathIsExit2(t *testing.T) {
 	}
 }
 
-func TestBadPrefixExit2(t *testing.T) {
-	r := runCmd(t, []string{"--first-party-prefix=QtFoo", "--stdin"}, formatted)
+func TestBadGroupPrefixExit2(t *testing.T) {
+	r := runCmd(t, []string{"--group=QtFoo", "--stdin"}, formatted)
 	if r.code != 2 {
 		t.Errorf("code = %d, want 2", r.code)
 	}
@@ -239,10 +239,34 @@ func TestBadPrefixExit2(t *testing.T) {
 	}
 }
 
-func TestFirstPartyPrefixIsApplied(t *testing.T) {
+func TestGroupIsApplied(t *testing.T) {
 	in := "import QtQuick\nimport com.acme.widgets\nimport io.github.someone\n\nRectangle {}\n"
 	want := "import QtQuick\n\nimport io.github.someone\n\nimport com.acme.widgets\n\nRectangle {}\n"
-	r := runCmd(t, []string{"--first-party-prefix=com.acme.", "--stdin"}, in)
+	r := runCmd(t, []string{"--group=com.acme.", "--stdin"}, in)
+	if r.code != 0 {
+		t.Errorf("code = %d, want 0; stderr=%q", r.code, r.stderr)
+	}
+	if r.stdout != want {
+		t.Errorf("stdout =\n%q\nwant\n%q", r.stdout, want)
+	}
+}
+
+func TestGroupSectionsFollowFlagOrder(t *testing.T) {
+	in := "import com.a.X\nimport com.b.X\nimport QtQuick\n\nRectangle {}\n"
+	want := "import QtQuick\n\nimport com.b.X\n\nimport com.a.X\n\nRectangle {}\n"
+	r := runCmd(t, []string{"--group=com.b.", "--group=com.a.", "--stdin"}, in)
+	if r.code != 0 {
+		t.Errorf("code = %d, want 0; stderr=%q", r.code, r.stderr)
+	}
+	if r.stdout != want {
+		t.Errorf("stdout =\n%q\nwant\n%q", r.stdout, want)
+	}
+}
+
+func TestGroupCommaSeparatedPrefixesShareSection(t *testing.T) {
+	in := "import com.b.X\nimport com.a.X\nimport QtQuick\n\nRectangle {}\n"
+	want := "import QtQuick\n\nimport com.a.X\nimport com.b.X\n\nRectangle {}\n"
+	r := runCmd(t, []string{"--group=com.a.,com.b.", "--stdin"}, in)
 	if r.code != 0 {
 		t.Errorf("code = %d, want 0; stderr=%q", r.code, r.stderr)
 	}

--- a/cmd/qmlimportsort/readme_test.go
+++ b/cmd/qmlimportsort/readme_test.go
@@ -11,21 +11,23 @@ import (
 	"testing"
 )
 
+var commandRe = regexp.MustCompile("`(qmlimportsort [^`]+)`")
+
 // TestReadmeExamples runs every marked example in README.MD against the
 // real CLI so the documentation cannot drift from the implementation.
 //
-// Convention: an "<!-- test:input -->" marker precedes the fenced block
-// holding the example source file; each "<!-- test:expect -->" marker
-// precedes a fenced block holding the expected output of the last
-// inline `qmlimportsort … <file>` command mentioned before the marker.
-// The command's trailing file argument is replaced by --stdin when it
+// Convention: a "<!-- test:input -->" marker is directly followed by the
+// fenced block holding the example source file; each "<!-- test:expect -->"
+// marker is directly followed by a fenced block holding the expected
+// output of the example command. The command is the single inline
+// `qmlimportsort … <file>` span in the paragraph directly above the
+// marker; its trailing file argument is replaced by --stdin when it
 // runs, feeding the input block and comparing stdout byte-for-byte.
 func TestReadmeExamples(t *testing.T) {
 	const (
 		inputMarker  = "<!-- test:input -->"
 		expectMarker = "<!-- test:expect -->"
 	)
-	commandRe := regexp.MustCompile("`(qmlimportsort [^`]+)`")
 
 	// Normalize line endings so a CRLF checkout (e.g. Windows CI with
 	// autocrlf) parses and compares the same as an LF one.
@@ -35,19 +37,15 @@ func TestReadmeExamples(t *testing.T) {
 	if len(inputParts) != 2 {
 		t.Fatalf("README must contain exactly one %q marker, found %d", inputMarker, len(inputParts)-1)
 	}
-	input := firstQMLFence(t, inputParts[1])
+	input := fenceDirectlyAfter(t, inputParts[1], inputMarker)
 
 	segments := strings.Split(readme, expectMarker)
 	if len(segments) < 2 {
 		t.Fatalf("README contains no %q marker", expectMarker)
 	}
 	for i := 1; i < len(segments); i++ {
-		commands := commandRe.FindAllStringSubmatch(segments[i-1], -1)
-		if commands == nil {
-			t.Fatalf("no inline `qmlimportsort …` command found before %q marker %d", expectMarker, i)
-		}
-		command := commands[len(commands)-1][1]
-		expected := firstQMLFence(t, segments[i])
+		command := commandAbove(t, segments[i-1], expectMarker, i)
+		expected := fenceDirectlyAfter(t, segments[i], expectMarker)
 
 		t.Run(command, func(t *testing.T) {
 			args := strings.Fields(command)[1:]
@@ -68,19 +66,35 @@ func TestReadmeExamples(t *testing.T) {
 	}
 }
 
-// firstQMLFence returns the content of the first ```qml code fence in s,
-// including the trailing newline.
-func firstQMLFence(t *testing.T, s string) string {
+// commandAbove extracts the example command from the paragraph directly
+// above occurrence n of marker (segment is the text before it).
+// Requiring exactly one command there keeps prose mentioning other
+// commands from silently swapping the command under test.
+func commandAbove(t *testing.T, segment, marker string, n int) string {
+	t.Helper()
+	paragraphs := strings.Split(strings.TrimSpace(segment), "\n\n")
+	paragraph := paragraphs[len(paragraphs)-1]
+	commands := commandRe.FindAllStringSubmatch(paragraph, -1)
+	if len(commands) != 1 {
+		t.Fatalf("want exactly one inline `qmlimportsort …` command in the paragraph above %q marker %d, found %d", marker, n, len(commands))
+	}
+	return commands[0][1]
+}
+
+// fenceDirectlyAfter returns the content of the ```qml fence that must
+// open directly after the marker (only blank lines in between), so a
+// deleted or drifted fence fails loudly instead of silently picking up
+// a later block.
+func fenceDirectlyAfter(t *testing.T, s, marker string) string {
 	t.Helper()
 	const open = "```qml\n"
-	_, after, ok := strings.Cut(s, open)
-	if !ok {
-		t.Fatalf("no %sfence found after marker", open)
+	head, body, ok := strings.Cut(s, open)
+	if !ok || strings.TrimSpace(head) != "" {
+		t.Fatalf("want a %sfence directly after the %q marker", open, marker)
 	}
-	body := after
 	j := strings.Index(body, "\n```")
 	if j < 0 {
-		t.Fatalf("unterminated %sfence after marker", open)
+		t.Fatalf("unterminated %sfence after the %q marker", open, marker)
 	}
 	return body[:j+1]
 }

--- a/cmd/qmlimportsort/readme_test.go
+++ b/cmd/qmlimportsort/readme_test.go
@@ -27,7 +27,9 @@ func TestReadmeExamples(t *testing.T) {
 	)
 	commandRe := regexp.MustCompile("`(qmlimportsort [^`]+)`")
 
-	readme := readFile(t, filepath.Join("..", "..", "README.MD"))
+	// Normalize line endings so a CRLF checkout (e.g. Windows CI with
+	// autocrlf) parses and compares the same as an LF one.
+	readme := strings.ReplaceAll(readFile(t, filepath.Join("..", "..", "README.MD")), "\r\n", "\n")
 
 	inputParts := strings.Split(readme, inputMarker)
 	if len(inputParts) != 2 {

--- a/cmd/qmlimportsort/readme_test.go
+++ b/cmd/qmlimportsort/readme_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Elias Mueller
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestReadmeExamples runs every marked example in README.MD against the
+// real CLI so the documentation cannot drift from the implementation.
+//
+// Convention: an "<!-- test:input -->" marker precedes the fenced block
+// holding the example source file; each "<!-- test:expect -->" marker
+// precedes a fenced block holding the expected output of the last
+// inline `qmlimportsort … <file>` command mentioned before the marker.
+// The command's trailing file argument is replaced by --stdin when it
+// runs, feeding the input block and comparing stdout byte-for-byte.
+func TestReadmeExamples(t *testing.T) {
+	const (
+		inputMarker  = "<!-- test:input -->"
+		expectMarker = "<!-- test:expect -->"
+	)
+	commandRe := regexp.MustCompile("`(qmlimportsort [^`]+)`")
+
+	readme := readFile(t, filepath.Join("..", "..", "README.MD"))
+
+	inputParts := strings.Split(readme, inputMarker)
+	if len(inputParts) != 2 {
+		t.Fatalf("README must contain exactly one %q marker, found %d", inputMarker, len(inputParts)-1)
+	}
+	input := firstQMLFence(t, inputParts[1])
+
+	segments := strings.Split(readme, expectMarker)
+	if len(segments) < 2 {
+		t.Fatalf("README contains no %q marker", expectMarker)
+	}
+	for i := 1; i < len(segments); i++ {
+		commands := commandRe.FindAllStringSubmatch(segments[i-1], -1)
+		if commands == nil {
+			t.Fatalf("no inline `qmlimportsort …` command found before %q marker %d", expectMarker, i)
+		}
+		command := commands[len(commands)-1][1]
+		expected := firstQMLFence(t, segments[i])
+
+		t.Run(command, func(t *testing.T) {
+			args := strings.Fields(command)[1:]
+			last := len(args) - 1
+			if last < 0 || strings.HasPrefix(args[last], "-") {
+				t.Fatalf("command %q must end with a file argument", command)
+			}
+			args[last] = "--stdin"
+
+			r := runCmd(t, args, input)
+			if r.code != 0 {
+				t.Fatalf("exit code = %d, stderr = %q", r.code, r.stderr)
+			}
+			if r.stdout != expected {
+				t.Errorf("README output drifted from the implementation\nwant:\n%s\ngot:\n%s", expected, r.stdout)
+			}
+		})
+	}
+}
+
+// firstQMLFence returns the content of the first ```qml code fence in s,
+// including the trailing newline.
+func firstQMLFence(t *testing.T, s string) string {
+	t.Helper()
+	const open = "```qml\n"
+	_, after, ok := strings.Cut(s, open)
+	if !ok {
+		t.Fatalf("no %sfence found after marker", open)
+	}
+	body := after
+	j := strings.Index(body, "\n```")
+	if j < 0 {
+		t.Fatalf("unterminated %sfence after marker", open)
+	}
+	return body[:j+1]
+}

--- a/docs/devel/CLI.md
+++ b/docs/devel/CLI.md
@@ -28,8 +28,65 @@ The flag list, synopsis, and exact mode behavior live in `qmlimportsort --help` 
 - **Processing order**: inputs in the order given on the command line; entries within a directory in lexical order, so `--check` output is deterministic.
 - **`--stdout` requires exactly one file**: there is no unambiguous way to concatenate multiple files' output.
 
+## Import grouping (`--group`)
+
+Imports are emitted in five sections, separated by blank lines and each sorted and deduplicated: **pragmas**, **Qt**, **everything else**, **custom sections**, **relative** (quoted paths).
+
+`--group <prefix>[,<prefix>...]` declares one custom section holding every import that starts with one of its prefixes. Repeat the flag to declare more sections; they appear in the order given.
+
+```shell
+# One section for company libraries, one for the app's own modules
+qmlimportsort --group Company.Shared.,Company.Widgets. --group MyApp. src/
+
+# The same prefixes as three separate sections
+qmlimportsort --group Company.Shared. --group Company.Widgets. --group MyApp. src/
+```
+
+The first command formats a file like this:
+
+```qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+
+import org.kde.kirigami as Kirigami
+
+import Company.Shared.Logging
+import Company.Widgets.Buttons
+
+import MyApp.Views
+
+import "./components"
+```
+
+The second command puts every namespace in its own section:
+
+```qml
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+
+import org.kde.kirigami as Kirigami
+
+import Company.Shared.Logging
+
+import Company.Widgets.Buttons
+
+import MyApp.Views
+
+import "./components"
+```
+
+End a prefix with `.` to avoid catching sibling modules: `MyApp.` matches `MyApp.Views` but not `MyAppExtras`. Invalid flags (empty, Qt-reserved, or duplicate prefixes) exit 2 before any file is touched.
+
+Full classification and validation semantics live in [INTERNAL_API.md](INTERNAL_API.md).
+
 ## Out of scope (deferred)
 
+- Config file (YAML or TOML). Planned — the repeatable `--group` flag is designed to map 1:1 onto it (schema sketch in [INTERNAL_API.md](INTERNAL_API.md)); CLI flags will take precedence when both are present.
+- Named prefix groups. Useful only once a config file exists (readability, error messages).
 - Subcommands (`format`, `check`, etc.) — can be added later non-breakingly if a genuinely new verb shows up.
 - `.gitignore` / `.qmlimportsortignore` support.
 - `--exclude` / `--include` patterns.

--- a/docs/devel/CLI.md
+++ b/docs/devel/CLI.md
@@ -79,7 +79,7 @@ import MyApp.Views
 import "./components"
 ```
 
-End a prefix with `.` to avoid catching sibling modules: `MyApp.` matches `MyApp.Views` but not `MyAppExtras`. Invalid flags (empty, `.`-leading, Qt-reserved, or duplicate prefixes) exit 2 before any file is touched.
+End a prefix with `.` to avoid catching sibling modules: `MyApp.` matches `MyApp.Views` but not `MyAppExtras`. Invalid flags (empty, never-matchable, Qt-reserved, or duplicate prefixes) exit 2 before any file is touched.
 
 Full classification and validation semantics live in [INTERNAL_API.md](INTERNAL_API.md).
 

--- a/docs/devel/CLI.md
+++ b/docs/devel/CLI.md
@@ -16,7 +16,7 @@ The flag list, synopsis, and exact mode behavior live in `qmlimportsort --help` 
 | 1    | At least one file changed (write mode) or would change (check mode).             |
 | 2    | Usage error, or one or more inputs failed (missing file, parse error, IO error). |
 
-`--stdin` and `--stdout` (without `--check`) always exit 0 on success — they are pipe-style modes; the user already sees the output and shell `&&` chains shouldn't break on a transformation.
+`--stdin` (without `--check`) and `--stdout` always exit 0 on success — they are pipe-style modes; the user already sees the output and shell `&&` chains shouldn't break on a transformation. Combining `--stdout` with `--check` is a usage error.
 
 ## Behavior guarantees
 
@@ -30,7 +30,7 @@ The flag list, synopsis, and exact mode behavior live in `qmlimportsort --help` 
 
 ## Import grouping (`--group`)
 
-Imports are emitted in five sections, separated by blank lines and each sorted and deduplicated: **pragmas**, **Qt**, **everything else**, **custom sections**, **relative** (quoted paths).
+Imports are emitted in this order, separated by blank lines and each sorted and deduplicated: **pragmas**, **Qt**, **default** (everything no group claims), **custom sections**, **relative** (quoted paths).
 
 `--group <prefix>[,<prefix>...]` declares one custom section holding every import that starts with one of its prefixes. Repeat the flag to declare more sections; they appear in the order given.
 
@@ -79,7 +79,7 @@ import MyApp.Views
 import "./components"
 ```
 
-End a prefix with `.` to avoid catching sibling modules: `MyApp.` matches `MyApp.Views` but not `MyAppExtras`. Invalid flags (empty, Qt-reserved, or duplicate prefixes) exit 2 before any file is touched.
+End a prefix with `.` to avoid catching sibling modules: `MyApp.` matches `MyApp.Views` but not `MyAppExtras`. Invalid flags (empty, `.`-leading, Qt-reserved, or duplicate prefixes) exit 2 before any file is touched.
 
 Full classification and validation semantics live in [INTERNAL_API.md](INTERNAL_API.md).
 

--- a/docs/devel/INTERNAL_API.md
+++ b/docs/devel/INTERNAL_API.md
@@ -42,8 +42,9 @@ Classification does not depend on flag order — it is decided per import:
 Validation happens in `qml.Compile`, so a bad group definition is a usage error (exit 2) before any file is touched:
 
 - a group with no prefixes at all
-- empty prefix, or prefix starting with `.`
-- Qt-reserved prefix: starting with `Qt` or `qt`, equal to `QML`, or starting with `QML.` — Qt-owned names always stay in the Qt section
+- empty prefix
+- a prefix that can never match an import: internal tabs or runs of spaces (import text is normalized to single spaces), or a module-name part that is not a valid QML-name prefix (ASCII letter or underscore first; then letters, digits, underscores, dots)
+- Qt-reserved prefix: starting with `Qt` or `qt`, equal to `QML`, or starting with `QML.` — the Qt/QML namespace cannot be grouped
 - the same prefix listed twice anywhere
 
 Overlapping (non-identical) prefixes are legal — the longest match wins, and because exact duplicates are rejected there are no ties.

--- a/docs/devel/INTERNAL_API.md
+++ b/docs/devel/INTERNAL_API.md
@@ -24,13 +24,40 @@ internal/
 
 ## Why `Compile` is separate from `Format`
 
-The CLI walks many files in one invocation and validates options once. `qml.Compile` does the validation and returns a `*Classifier`; `qml.Format` trusts its input. The CLI calls `Compile` at flag-parse time and treats a `Compile` error as a usage error (exit 2), so a bad `--first-party-prefix` fails before any file is touched.
+The CLI walks many files in one invocation and validates options once. `qml.Compile` does the validation and returns a `*Classifier`; `qml.Format` trusts its input. The CLI calls `Compile` at flag-parse time and treats a `Compile` error as a usage error (exit 2), so a bad `--group` fails before any file is touched.
 
 The full API surface and behavior contract live in the godoc on the `qml` and `fs` packages.
 
+## Import classification and grouping
+
+The output order of the import block is fixed: pragmas, Qt, default, custom `--group` sections (in flag order), relative. Only the custom sections are configurable.
+
+Classification does not depend on flag order — it is decided per import:
+
+- **Relative** matches by syntax: the import target is a quoted path.
+- **Qt** matches modules shipped with Qt: names starting with `Qt` followed by an uppercase letter, digit, or dot (`QtQuick`, `Qt.labs.settings`, `Qt5Compat.GraphicalEffects`), plus the base language module `QML`.
+- **Custom sections** match by the longest matching prefix across *all* `--group` flags. A prefix is a literal match against the whitespace-normalized text after `import`; a trailing `.` creates a namespace boundary (`io.github.mpvqc.` matches `io.github.mpvqc.Foo` but not `io.github.mpvqcExternal`). Prefixes are trimmed of surrounding whitespace.
+- **Default** takes whatever is left.
+
+Validation happens in `qml.Compile`, so a bad group definition is a usage error (exit 2) before any file is touched:
+
+- empty prefix, or prefix starting with `.`
+- Qt-reserved prefix: starting with `Qt` or `qt`, equal to `QML`, or starting with `QML.` — Qt-owned names always stay in the Qt section
+- the same prefix listed twice anywhere
+
+Overlapping (non-identical) prefixes are legal — the longest match wins, and because exact duplicates are rejected there are no ties.
+
+The repeatable flag maps 1:1 onto a list in the planned YAML/TOML config file:
+
+```yaml
+groups:
+  - prefixes: [Company.Shared., Company.Widgets.]
+  - prefixes: [MyApp.]
+```
+
 ## How the CLI modes compose
 
-Each flag mode in [CLI.md](CLI.md) maps to a small combination of `fs` primitives. `main` contains no formatting logic — only dispatch. It builds a `qml.Options` from `--first-party-prefix` flags, calls `qml.Compile` once, and threads the resulting `*qml.Classifier` through every `fs` call.
+Each flag mode in [CLI.md](CLI.md) maps to a small combination of `fs` primitives. `main` contains no formatting logic — only dispatch. It builds a `qml.Options` from `--group` flags, calls `qml.Compile` once, and threads the resulting `*qml.Classifier` through every `fs` call.
 
 | Mode                            | Composition                                                                                               |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------- |

--- a/docs/devel/INTERNAL_API.md
+++ b/docs/devel/INTERNAL_API.md
@@ -20,7 +20,7 @@ internal/
 └── fs/      # I/O shell: file reads, directory walks, atomic writes, stdin/stdout glue.
 ```
 
-`main` imports `internal/fs`. `internal/fs` imports `internal/qml`. `internal/qml` imports only the stdlib's pure packages.
+`main` imports `internal/fs` and `internal/qml` (for `Compile`). `internal/fs` imports `internal/qml`. `internal/qml` imports only the stdlib's pure packages.
 
 ## Why `Compile` is separate from `Format`
 
@@ -35,12 +35,13 @@ The output order of the import block is fixed: pragmas, Qt, default, custom `--g
 Classification does not depend on flag order — it is decided per import:
 
 - **Relative** matches by syntax: the import target is a quoted path.
-- **Qt** matches modules shipped with Qt: names starting with `Qt` followed by an uppercase letter, digit, or dot (`QtQuick`, `Qt.labs.settings`, `Qt5Compat.GraphicalEffects`), plus the base language module `QML`.
+- **Qt** matches modules shipped with Qt: names starting with `Qt` followed by an uppercase letter, digit, or dot (`QtQuick`, `Qt.labs.settings`, `Qt5Compat.GraphicalEffects`), plus the base language module `QML` and its `QML.` subpaths.
 - **Custom sections** match by the longest matching prefix across *all* `--group` flags. A prefix is a literal match against the whitespace-normalized text after `import`; a trailing `.` creates a namespace boundary (`io.github.mpvqc.` matches `io.github.mpvqc.Foo` but not `io.github.mpvqcExternal`). Prefixes are trimmed of surrounding whitespace.
 - **Default** takes whatever is left.
 
 Validation happens in `qml.Compile`, so a bad group definition is a usage error (exit 2) before any file is touched:
 
+- a group with no prefixes at all
 - empty prefix, or prefix starting with `.`
 - Qt-reserved prefix: starting with `Qt` or `qt`, equal to `QML`, or starting with `QML.` — Qt-owned names always stay in the Qt section
 - the same prefix listed twice anywhere

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@
 
 module github.com/trin94/qml-import-sort
 
-go 1.24.0
+go 1.26.0

--- a/internal/qml/classifier.go
+++ b/internal/qml/classifier.go
@@ -21,7 +21,7 @@ type Options struct {
 	// import:
 	//
 	//  1. pragma keyword                → pragma
-	//  2. Qt[A-Z0-9.] pattern or QML    → qt
+	//  2. Qt[A-Z0-9.], QML, or QML.…    → qt
 	//  3. text starts with " or '       → relative
 	//  4. longest matching prefix       → that prefix's group
 	//  5. otherwise (valid identifier)  → default
@@ -40,8 +40,8 @@ type Options struct {
 	// Prefixes are trimmed of leading and trailing whitespace before
 	// validation and matching.
 	//
-	// Compile validates each group and returns an error naming the
-	// offending prefix if any rule is violated:
+	// Compile validates each group and returns an error identifying
+	// the offending prefix or group if any rule is violated:
 	//
 	//   - a group without prefixes
 	//   - empty prefix (after trimming)
@@ -65,7 +65,8 @@ type Classifier struct {
 
 // Compile validates opts and returns a Classifier suitable for Format.
 // See Options.Groups for the validation rules; Compile returns an
-// error naming the offending prefix when any rule is violated.
+// error identifying the offending prefix or group when any rule is
+// violated.
 func Compile(opts Options) (*Classifier, error) {
 	groups := make([][]string, 0, len(opts.Groups))
 	seen := make(map[string]bool)
@@ -102,7 +103,7 @@ func isQtReservedPrefix(p string) bool {
 }
 
 // matchGroup returns the index of the group holding the longest prefix
-// matching text, or false when no prefix matches.
+// matching text; the boolean reports whether any prefix matched.
 func (c *Classifier) matchGroup(text string) (int, bool) {
 	best, bestLen := -1, 0
 	for i, prefixes := range c.groups {

--- a/internal/qml/classifier.go
+++ b/internal/qml/classifier.go
@@ -45,10 +45,14 @@ type Options struct {
 	//
 	//   - a group without prefixes
 	//   - empty prefix (after trimming)
-	//   - prefix starting with "."
-	//   - prefix starting with "Qt" or "qt", equal to "QML", or
-	//     starting with "QML." (Qt-owned names always stay in the Qt
-	//     section)
+	//   - a prefix that can never match: containing a tab or a run of
+	//     two or more spaces (import text is normalized to single
+	//     spaces), or whose module-name part is not a valid QML-name
+	//     prefix (ASCII letter or underscore first; then letters,
+	//     digits, underscores, dots)
+	//   - a Qt-reserved prefix — starting with "Qt" or "qt", equal to
+	//     "QML", or starting with "QML." — the Qt/QML namespace cannot
+	//     be grouped
 	//   - the same prefix listed twice anywhere
 	Groups [][]string
 }
@@ -77,16 +81,16 @@ func Compile(opts Options) (*Classifier, error) {
 		prefixes := make([]string, 0, len(rawGroup))
 		for _, raw := range rawGroup {
 			p := strings.TrimSpace(raw)
-			if p == "" {
+			switch {
+			case p == "":
 				return nil, errors.New("qml.Compile: empty prefix")
-			}
-			if strings.HasPrefix(p, ".") {
-				return nil, fmt.Errorf("qml.Compile: prefix %q starts with %q", p, ".")
-			}
-			if isQtReservedPrefix(p) {
-				return nil, fmt.Errorf("qml.Compile: prefix %q is reserved (Qt-owned names always stay in the Qt section)", p)
-			}
-			if seen[p] {
+			case strings.ContainsAny(p, "\t\r\n") || strings.Contains(p, "  "):
+				return nil, fmt.Errorf("qml.Compile: prefix %q can never match: import text uses single spaces", p)
+			case !isMatchablePrefix(p):
+				return nil, fmt.Errorf("qml.Compile: prefix %q can never match a QML module name", p)
+			case isQtReservedPrefix(p):
+				return nil, fmt.Errorf("qml.Compile: prefix %q is reserved: the Qt/QML namespace cannot be grouped", p)
+			case seen[p]:
 				return nil, fmt.Errorf("qml.Compile: duplicate prefix %q", p)
 			}
 			seen[p] = true
@@ -100,6 +104,24 @@ func Compile(opts Options) (*Classifier, error) {
 func isQtReservedPrefix(p string) bool {
 	return strings.HasPrefix(p, "Qt") || strings.HasPrefix(p, "qt") ||
 		p == "QML" || strings.HasPrefix(p, "QML.")
+}
+
+// isMatchablePrefix reports whether p could prefix the whitespace-
+// normalized text of a groupable import: its module-name part must be
+// a valid QML-name prefix. Anything after the first space (version,
+// alias, trailing comment) is deliberately not validated.
+func isMatchablePrefix(p string) bool {
+	name, _, _ := strings.Cut(p, " ")
+	if !isLetter(name[0]) && name[0] != '_' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		c := name[i]
+		if !isLetter(c) && !isDigit(c) && c != '_' && c != '.' {
+			return false
+		}
+	}
+	return true
 }
 
 // matchGroup returns the index of the group holding the longest prefix

--- a/internal/qml/classifier.go
+++ b/internal/qml/classifier.go
@@ -12,22 +12,19 @@ import (
 
 // Options configure Format's classifier. The zero value preserves
 // Format's default behavior: every non-Qt, non-relative import lands
-// in a single third-party group.
+// in the single default section.
 type Options struct {
 
-	// FirstPartyPrefixes carves a first-party group out of the default
-	// third-party set. The classifier checks these rules top-to-bottom;
-	// the first match wins:
+	// Groups declares the custom sections emitted between the default
+	// and relative sections, in order; each inner slice holds the
+	// prefixes of one section. The classifier decides membership per
+	// import:
 	//
 	//  1. pragma keyword                → pragma
 	//  2. Qt[A-Z0-9.] pattern or QML    → qt
 	//  3. text starts with " or '       → relative
-	//  4. FirstPartyPrefixes match      → first-party
-	//  5. otherwise (valid identifier)  → third-party
-	//
-	// There is no dotted-vs-bare heuristic: a bare identifier and a
-	// dotted path are both third-party by default, and the caller
-	// decides which (if any) become first-party.
+	//  4. longest matching prefix       → that prefix's group
+	//  5. otherwise (valid identifier)  → default
 	//
 	// A prefix is a literal byte-level string match against the import
 	// text (the content after "import " with leading/trailing
@@ -35,74 +32,85 @@ type Options struct {
 	// a trailing "." to match only dotted subpaths — "io.github.mpvqc."
 	// matches "io.github.mpvqc.Foo" but not "io.github.mpvqcExternal".
 	//
+	// Matching uses the longest prefix across all groups, so the order
+	// of Groups affects only where sections appear, never which group
+	// an import belongs to. Overlapping prefixes are legal; exact
+	// duplicates are not, so there are no ties.
+	//
 	// Prefixes are trimmed of leading and trailing whitespace before
-	// validation and matching. Trim happens before every rule below,
-	// so "   " is rejected as empty and "  Qt  " is rejected for
-	// starting with "Qt".
+	// validation and matching.
 	//
-	// Format validates each prefix at entry and returns an error
-	// naming the offending prefix(es) if any rule is violated:
+	// Compile validates each group and returns an error naming the
+	// offending prefix if any rule is violated:
 	//
-	//   - empty (after trimming)
-	//   - starts with "."
-	//   - starts with "Qt" or "qt" (Qt is its own category)
-	//   - equals "QML" or starts with "QML." (the QML base module
-	//     belongs to the Qt category)
-	//   - equals "pragma" (pragma is its own category)
-	//   - any two prefixes overlap — identical, or one is a prefix of
-	//     the other (reported as "duplicate" or "overlapping"
-	//     respectively)
-	FirstPartyPrefixes []string
+	//   - a group without prefixes
+	//   - empty prefix (after trimming)
+	//   - prefix starting with "."
+	//   - prefix starting with "Qt" or "qt", equal to "QML", or
+	//     starting with "QML." (Qt-owned names always stay in the Qt
+	//     section)
+	//   - the same prefix listed twice anywhere
+	Groups [][]string
 }
 
 // Classifier is a compiled, validated form of Options. Build one with
-// Compile (or MustCompile) and pass it to Format; a nil *Classifier is
-// equivalent to one compiled from Options{}, i.e. defaults only.
+// Compile and pass it to Format; a nil *Classifier is equivalent to one
+// compiled from Options{}, i.e. defaults only.
 //
 // Compile once and reuse across files. The returned Classifier is
 // immutable and safe for concurrent use.
 type Classifier struct {
-	firstPartyPrefixes []string
+	groups [][]string
 }
 
 // Compile validates opts and returns a Classifier suitable for Format.
-// See Options.FirstPartyPrefixes for the validation rules; Compile
-// returns an error naming the offending prefix(es) when any rule is
-// violated.
+// See Options.Groups for the validation rules; Compile returns an
+// error naming the offending prefix when any rule is violated.
 func Compile(opts Options) (*Classifier, error) {
-	prefixes := make([]string, 0, len(opts.FirstPartyPrefixes))
-	for _, raw := range opts.FirstPartyPrefixes {
-		p := strings.TrimSpace(raw)
-		if p == "" {
-			return nil, errors.New("qml.Compile: empty prefix")
+	groups := make([][]string, 0, len(opts.Groups))
+	seen := make(map[string]bool)
+	for i, rawGroup := range opts.Groups {
+		if len(rawGroup) == 0 {
+			return nil, fmt.Errorf("qml.Compile: group %d has no prefixes", i+1)
 		}
-		if strings.HasPrefix(p, ".") {
-			return nil, fmt.Errorf("qml.Compile: prefix %q starts with %q", p, ".")
+		prefixes := make([]string, 0, len(rawGroup))
+		for _, raw := range rawGroup {
+			p := strings.TrimSpace(raw)
+			if p == "" {
+				return nil, errors.New("qml.Compile: empty prefix")
+			}
+			if strings.HasPrefix(p, ".") {
+				return nil, fmt.Errorf("qml.Compile: prefix %q starts with %q", p, ".")
+			}
+			if isQtReservedPrefix(p) {
+				return nil, fmt.Errorf("qml.Compile: prefix %q is reserved (Qt-owned names always stay in the Qt section)", p)
+			}
+			if seen[p] {
+				return nil, fmt.Errorf("qml.Compile: duplicate prefix %q", p)
+			}
+			seen[p] = true
+			prefixes = append(prefixes, p)
 		}
-		if strings.HasPrefix(p, "Qt") || strings.HasPrefix(p, "qt") {
-			return nil, fmt.Errorf("qml.Compile: prefix %q starts with Qt/qt (Qt is its own category)", p)
-		}
-		if p == "QML" || strings.HasPrefix(p, "QML.") {
-			return nil, fmt.Errorf("qml.Compile: prefix %q is reserved (the QML base module belongs to the Qt category)", p)
-		}
-		if p == "pragma" {
-			return nil, fmt.Errorf("qml.Compile: prefix %q is reserved (pragma is its own category)", p)
-		}
-		prefixes = append(prefixes, p)
+		groups = append(groups, prefixes)
 	}
-	for i, a := range prefixes {
-		for _, b := range prefixes[i+1:] {
-			if a == b {
-				return nil, fmt.Errorf("qml.Compile: duplicate prefix %q", a)
-			}
-			short, long := a, b
-			if len(b) < len(a) {
-				short, long = b, a
-			}
-			if strings.HasPrefix(long, short) {
-				return nil, fmt.Errorf("qml.Compile: overlapping prefixes %q and %q (%q is a prefix of %q)", a, b, short, long)
+	return &Classifier{groups: groups}, nil
+}
+
+func isQtReservedPrefix(p string) bool {
+	return strings.HasPrefix(p, "Qt") || strings.HasPrefix(p, "qt") ||
+		p == "QML" || strings.HasPrefix(p, "QML.")
+}
+
+// matchGroup returns the index of the group holding the longest prefix
+// matching text, or false when no prefix matches.
+func (c *Classifier) matchGroup(text string) (int, bool) {
+	best, bestLen := -1, 0
+	for i, prefixes := range c.groups {
+		for _, p := range prefixes {
+			if len(p) > bestLen && strings.HasPrefix(text, p) {
+				best, bestLen = i, len(p)
 			}
 		}
 	}
-	return &Classifier{firstPartyPrefixes: prefixes}, nil
+	return best, best >= 0
 }

--- a/internal/qml/classifier_test.go
+++ b/internal/qml/classifier_test.go
@@ -16,68 +16,80 @@ func TestCompile(t *testing.T) {
 		wantErrContains string
 	}{
 		{
+			name: "no groups is valid",
+			opts: Options{},
+		},
+		{
 			name:            "empty prefix is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{""}},
+			opts:            Options{Groups: [][]string{{""}}},
 			wantErrContains: "empty prefix",
 		},
 		{
 			name:            "all-whitespace prefix is trimmed to empty and rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"   "}},
+			opts:            Options{Groups: [][]string{{"   "}}},
 			wantErrContains: "empty prefix",
 		},
 		{
+			name:            "group without prefixes is rejected",
+			opts:            Options{Groups: [][]string{{}}},
+			wantErrContains: "no prefixes",
+		},
+		{
 			name:            "prefix starting with '.' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{".foo"}},
+			opts:            Options{Groups: [][]string{{".foo"}}},
 			wantErrContains: `".foo"`,
 		},
 		{
-			name:            "prefix equal to 'pragma' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"pragma"}},
-			wantErrContains: `"pragma"`,
-		},
-		{
 			name:            "prefix starting with 'Qt' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"QtCustom"}},
+			opts:            Options{Groups: [][]string{{"QtCustom"}}},
 			wantErrContains: `"QtCustom"`,
 		},
 		{
 			name:            "prefix starting with 'qt' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"qtcustom"}},
+			opts:            Options{Groups: [][]string{{"qtcustom"}}},
 			wantErrContains: `"qtcustom"`,
 		},
 		{
-			name:            "prefix with surrounding whitespace is trimmed before the Qt-start check",
-			opts:            Options{FirstPartyPrefixes: []string{"  QtCustom  "}},
-			wantErrContains: `"QtCustom"`,
-		},
-		{
 			name:            "prefix equal to 'QML' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"QML"}},
+			opts:            Options{Groups: [][]string{{"QML"}}},
 			wantErrContains: `"QML"`,
 		},
 		{
 			name:            "prefix starting with 'QML.' is rejected",
-			opts:            Options{FirstPartyPrefixes: []string{"QML.Foo"}},
+			opts:            Options{Groups: [][]string{{"QML.Foo"}}},
 			wantErrContains: `"QML.Foo"`,
 		},
 		{
 			name: "prefix merely starting with QML is accepted",
-			opts: Options{FirstPartyPrefixes: []string{"QMLFoo"}},
+			opts: Options{Groups: [][]string{{"QMLFoo"}}},
 		},
 		{
-			name:            "duplicate prefix is rejected and names the prefix",
-			opts:            Options{FirstPartyPrefixes: []string{"Foo", "Foo"}},
+			name:            "prefix with surrounding whitespace is trimmed before the Qt-start check",
+			opts:            Options{Groups: [][]string{{"  QtCustom  "}}},
+			wantErrContains: `"QtCustom"`,
+		},
+		{
+			name:            "duplicate prefix within a group is rejected",
+			opts:            Options{Groups: [][]string{{"Foo", "Foo"}}},
 			wantErrContains: `"Foo"`,
 		},
 		{
-			name:            "prefix-of-prefix overlap is rejected and names both (shorter first)",
-			opts:            Options{FirstPartyPrefixes: []string{"Foo", "Foo.Bar"}},
-			wantErrContains: `"Foo.Bar"`,
+			name:            "duplicate prefix across groups is rejected",
+			opts:            Options{Groups: [][]string{{"Foo"}, {"Foo"}}},
+			wantErrContains: `"Foo"`,
 		},
 		{
-			name:            "prefix-of-prefix overlap is detected regardless of order (longer first)",
-			opts:            Options{FirstPartyPrefixes: []string{"Foo.Bar", "Foo"}},
-			wantErrContains: `"Foo.Bar"`,
+			name:            "duplicates are detected after trimming",
+			opts:            Options{Groups: [][]string{{"Foo"}, {"  Foo  "}}},
+			wantErrContains: `"Foo"`,
+		},
+		{
+			name: "overlapping prefixes in one group are accepted",
+			opts: Options{Groups: [][]string{{"Foo.", "Foo.Bar."}}},
+		},
+		{
+			name: "overlapping prefixes across groups are accepted",
+			opts: Options{Groups: [][]string{{"Foo."}, {"Foo.Bar."}}},
 		},
 	}
 

--- a/internal/qml/classifier_test.go
+++ b/internal/qml/classifier_test.go
@@ -91,6 +91,48 @@ func TestCompile(t *testing.T) {
 			name: "overlapping prefixes across groups are accepted",
 			opts: Options{Groups: [][]string{{"Foo."}, {"Foo.Bar."}}},
 		},
+		{
+			name:            "Qt-reserved rejection names the namespace policy",
+			opts:            Options{Groups: [][]string{{"QtCustom"}}},
+			wantErrContains: "reserved",
+		},
+		{
+			name:            "prefix with a run of spaces can never match and is rejected",
+			opts:            Options{Groups: [][]string{{"My  Lib"}}},
+			wantErrContains: `"My  Lib"`,
+		},
+		{
+			name:            "prefix containing a tab can never match and is rejected",
+			opts:            Options{Groups: [][]string{{"My\tLib"}}},
+			wantErrContains: "can never match",
+		},
+		{
+			name:            "prefix with non-ASCII module name can never match and is rejected",
+			opts:            Options{Groups: [][]string{{"Café."}}},
+			wantErrContains: `"Café."`,
+		},
+		{
+			name:            "prefix starting with a digit can never match and is rejected",
+			opts:            Options{Groups: [][]string{{"9foo"}}},
+			wantErrContains: `"9foo"`,
+		},
+		{
+			name:            "prefix starting with a quote can never match and is rejected",
+			opts:            Options{Groups: [][]string{{`"x`}}},
+			wantErrContains: "can never match",
+		},
+		{
+			name: "prefix 'pragma' is accepted since a module may be named pragma",
+			opts: Options{Groups: [][]string{{"pragma"}}},
+		},
+		{
+			name: "underscore-leading prefix is accepted",
+			opts: Options{Groups: [][]string{{"_private."}}},
+		},
+		{
+			name: "prefix extending past the module name is accepted",
+			opts: Options{Groups: [][]string{{"MyLib 1.0"}}},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/qml/format.go
+++ b/internal/qml/format.go
@@ -23,11 +23,11 @@ import (
 // the author left a blank line before the imports, the formatter
 // supplies one.
 //
-// The block is classified into five categories — pragma, qt,
-// third-party, first-party, relative — and emitted in that fixed
-// order. Within each, entries sort by normalized text in byte order
+// The block is classified into sections — pragma, qt, default, one
+// section per custom group, relative — and emitted in that order.
+// Within each, entries sort by normalized text in byte order
 // (case-sensitive, so "A" < "a"). Duplicates are removed; the first
-// occurrence wins. Empty categories emit nothing.
+// occurrence wins. Empty sections emit nothing.
 //
 // Comments inside the block are hoisted: they are collected in input
 // order and emitted as a single section between the preamble and the
@@ -90,7 +90,7 @@ func Format(src []byte, c *Classifier) ([]byte, error) {
 			return nil, err
 		}
 		hoisted = extractComments(tokens)
-		block = emitGroups(groupAndSort(tokens))
+		block = emitGroups(groupAndSort(tokens, len(c.groups)))
 	}
 
 	var out []string
@@ -191,14 +191,15 @@ const (
 	kindBlockComment
 	kindPragma
 	kindQt
-	kindThirdParty
-	kindFirstParty
+	kindDefault
+	kindCustom
 	kindRelative
 )
 
 type blockToken struct {
-	kind lineKind
-	text string // canonical form for normal lines; original (with leading whitespace) for block comments
+	kind  lineKind
+	group int    // custom-section index, meaningful only for kindCustom
+	text  string // canonical form for normal lines; original (with leading whitespace) for block comments
 }
 
 // extractComments returns the canonical text of every comment line in
@@ -215,30 +216,39 @@ func extractComments(tokens []blockToken) []string {
 	return out
 }
 
-// emitOrder fixes the sequence in which import categories appear in the
-// output. Comments are extracted separately by extractComments and
-// emitted as a hoisted section between preamble and the import groups.
-var emitOrder = []lineKind{kindPragma, kindQt, kindThirdParty, kindFirstParty, kindRelative}
-
-// groupAndSort buckets tokens by category, sorts each bucket by text in
-// byte order, removes byte-identical duplicates, and returns one slice
-// per category in emitOrder. Comments are dropped.
-func groupAndSort(tokens []blockToken) [][]blockToken {
-	groups := make(map[lineKind][]blockToken)
+// groupAndSort buckets tokens into emitted sections — pragma, qt,
+// default, one section per custom group, relative, in that order —
+// sorts each section by text in byte order, and removes byte-identical
+// duplicates. Comments are dropped; extractComments emits them as a
+// hoisted section between preamble and the import sections.
+func groupAndSort(tokens []blockToken, groupCount int) [][]blockToken {
+	sections := make([][]blockToken, groupCount+4)
+	sectionIndex := func(t blockToken) int {
+		switch t.kind {
+		case kindPragma:
+			return 0
+		case kindQt:
+			return 1
+		case kindDefault:
+			return 2
+		case kindCustom:
+			return 3 + t.group
+		default: // kindRelative
+			return 3 + groupCount
+		}
+	}
 	for _, t := range tokens {
 		if t.kind == kindLineComment || t.kind == kindBlockComment {
 			continue
 		}
-		groups[t.kind] = append(groups[t.kind], t)
+		i := sectionIndex(t)
+		sections[i] = append(sections[i], t)
 	}
-	result := make([][]blockToken, len(emitOrder))
-	for i, k := range emitOrder {
-		g := groups[k]
+	for i, g := range sections {
 		slices.SortFunc(g, func(a, b blockToken) int { return strings.Compare(a.text, b.text) })
-		g = slices.CompactFunc(g, func(a, b blockToken) bool { return a.text == b.text })
-		result[i] = g
+		sections[i] = slices.CompactFunc(g, func(a, b blockToken) bool { return a.text == b.text })
 	}
-	return result
+	return sections
 }
 
 // emitGroups flattens grouped tokens into output lines, inserting one
@@ -327,12 +337,10 @@ func classifyImport(line string, c *Classifier) (blockToken, error) {
 	}
 
 	matchText := strings.Join(tokens[1:], " ")
-	for _, p := range c.firstPartyPrefixes {
-		if strings.HasPrefix(matchText, p) {
-			return blockToken{kind: kindFirstParty, text: canonical}, nil
-		}
+	if g, ok := c.matchGroup(matchText); ok {
+		return blockToken{kind: kindCustom, group: g, text: canonical}, nil
 	}
-	return blockToken{kind: kindThirdParty, text: canonical}, nil
+	return blockToken{kind: kindDefault, text: canonical}, nil
 }
 
 // splitImportTokens splits a pragma or import line into whitespace-

--- a/internal/qml/format.go
+++ b/internal/qml/format.go
@@ -56,7 +56,8 @@ import (
 // Line endings are detected from the input — the first \n, \r\n, or
 // \r wins — and used throughout the output.
 //
-// A file with no imports (and no pragmas) is returned unchanged.
+// A file with no imports (and no pragmas) is returned unchanged,
+// except that leading blank lines are still stripped.
 //
 // Returns an error if a line inside the block is not a pragma, import,
 // comment, or blank. Options validation errors come from Compile, not

--- a/internal/qml/format_test.go
+++ b/internal/qml/format_test.go
@@ -85,7 +85,7 @@ func TestFormatClassification(t *testing.T) {
 			},
 		},
 		{
-			name:       "single dotted third-party import passes through unchanged",
+			name:       "single dotted default-section import passes through unchanged",
 			lineEnding: "\n",
 			input: []string{
 				"import io.github.me 1.0",
@@ -101,7 +101,7 @@ func TestFormatClassification(t *testing.T) {
 			},
 		},
 		{
-			name:       "single bare-identifier third-party import passes through unchanged",
+			name:       "single bare-identifier default-section import passes through unchanged",
 			lineEnding: "\n",
 			input: []string{
 				"import MyModule",
@@ -189,7 +189,7 @@ func TestFormatClassification(t *testing.T) {
 			},
 		},
 		{
-			name:       "module name merely starting with QML stays third-party",
+			name:       "module name merely starting with QML stays in the default section",
 			lineEnding: "\n",
 			input: []string{
 				"import QMLFoo",
@@ -244,7 +244,7 @@ func TestFormatClassification(t *testing.T) {
 			},
 		},
 		{
-			name:       "dotted third-party import without version classifies correctly",
+			name:       "dotted default-section import without version classifies correctly",
 			lineEnding: "\n",
 			input: []string{
 				"import io.github.me",
@@ -260,7 +260,7 @@ func TestFormatClassification(t *testing.T) {
 			},
 		},
 		{
-			name:       "bare-identifier third-party import with version classifies correctly",
+			name:       "bare-identifier default-section import with version classifies correctly",
 			lineEnding: "\n",
 			input: []string{
 				"import MyModule 1.0",

--- a/internal/qml/format_test.go
+++ b/internal/qml/format_test.go
@@ -1396,12 +1396,12 @@ func TestFormatIntegration(t *testing.T) {
 	})
 }
 
-func TestFormatFirstPartyPrefixes(t *testing.T) {
+func TestFormatGroups(t *testing.T) {
 	runFormatCases(t, []formatCase{
 		{
-			name:       "first-party prefix carves a bare identifier out of third-party",
+			name:       "a group carves its imports out of default into a section after it",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"MyLib"}},
+			options:    Options{Groups: [][]string{{"MyLib"}}},
 			input: []string{
 				"import MyLib",
 				"import QtQuick",
@@ -1419,29 +1419,100 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:       "first-party prefix matches a dotted name",
+			name:       "custom sections sit between default and relative",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"io.github.mpvqc."}},
+			options:    Options{Groups: [][]string{{"MyApp."}}},
 			input: []string{
-				"import io.github.mpvqc.Foo",
-				"import io.github.other",
+				`import "./components"`,
+				"import MyApp.Views",
+				"import PlainModule",
+				"import QtQuick",
 				"",
 				"Rectangle {",
 				"}",
 			},
 			expected: []string{
-				"import io.github.other",
+				"import QtQuick",
 				"",
-				"import io.github.mpvqc.Foo",
+				"import PlainModule",
+				"",
+				"import MyApp.Views",
+				"",
+				`import "./components"`,
 				"",
 				"Rectangle {",
 				"}",
 			},
 		},
 		{
-			name:       "trailing dot in the prefix creates a boundary that does not match siblings",
+			name:       "prefixes in one group share a single section",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"io.github.mpvqc."}},
+			options:    Options{Groups: [][]string{{"Company.Shared.", "Company.Widgets."}}},
+			input: []string{
+				"import Company.Widgets.Buttons",
+				"import Company.Shared.Logging",
+				"import PlainModule",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			expected: []string{
+				"import PlainModule",
+				"",
+				"import Company.Shared.Logging",
+				"import Company.Widgets.Buttons",
+				"",
+				"Rectangle {",
+				"}",
+			},
+		},
+		{
+			name:       "separate groups emit separate sections in group order",
+			lineEnding: "\n",
+			options:    Options{Groups: [][]string{{"Beta."}, {"Alpha."}}},
+			input: []string{
+				"import Alpha.One",
+				"import Beta.One",
+				"import QtQuick",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			expected: []string{
+				"import QtQuick",
+				"",
+				"import Beta.One",
+				"",
+				"import Alpha.One",
+				"",
+				"Rectangle {",
+				"}",
+			},
+		},
+		{
+			name:       "longest matching prefix wins regardless of group order",
+			lineEnding: "\n",
+			options:    Options{Groups: [][]string{{"Foo."}, {"Foo.Bar."}}},
+			input: []string{
+				"import Foo.Bar.X",
+				"import Foo.Y",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			expected: []string{
+				"import Foo.Y",
+				"",
+				"import Foo.Bar.X",
+				"",
+				"Rectangle {",
+				"}",
+			},
+		},
+		{
+			name:       "trailing dot in a prefix creates a boundary that does not match siblings",
+			lineEnding: "\n",
+			options:    Options{Groups: [][]string{{"io.github.mpvqc."}}},
 			input: []string{
 				"import io.github.mpvqc.Foo",
 				"import io.github.mpvqcExternal.Bar",
@@ -1459,7 +1530,27 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:       "default options put every non-Qt non-relative import into a single third-party group",
+			name:       "group with no matching imports emits nothing",
+			lineEnding: "\n",
+			options:    Options{Groups: [][]string{{"Unused."}}},
+			input: []string{
+				"import PlainModule",
+				"import QtQuick",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			expected: []string{
+				"import QtQuick",
+				"",
+				"import PlainModule",
+				"",
+				"Rectangle {",
+				"}",
+			},
+		},
+		{
+			name:       "default options put every non-Qt non-relative import into a single default section",
 			lineEnding: "\n",
 			input: []string{
 				"import QtQuick",
@@ -1480,31 +1571,9 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:       "multiple first-party prefixes are all honored",
+			name:       "group prefix matches imports with a trailing '//' comment",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"Alpha", "Beta"}},
-			input: []string{
-				"import Alpha",
-				"import Beta",
-				"import Gamma",
-				"",
-				"Rectangle {",
-				"}",
-			},
-			expected: []string{
-				"import Gamma",
-				"",
-				"import Alpha",
-				"import Beta",
-				"",
-				"Rectangle {",
-				"}",
-			},
-		},
-		{
-			name:       "first-party prefix matches imports with a trailing '//' comment",
-			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"MyLib"}},
+			options:    Options{Groups: [][]string{{"MyLib"}}},
 			input: []string{
 				"import MyLib // project internal library",
 				"import PlainModule",
@@ -1524,7 +1593,7 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 		{
 			name:       "leading and trailing whitespace in prefixes is trimmed before use",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"  MyLib  "}},
+			options:    Options{Groups: [][]string{{"  MyLib  "}}},
 			input: []string{
 				"import MyLib",
 				"import PlainModule",
@@ -1542,9 +1611,9 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:       "first-party prefix matches against whitespace-normalized import text",
+			name:       "group prefix matches against whitespace-normalized import text",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"MyLib 1.0"}},
+			options:    Options{Groups: [][]string{{"MyLib 1.0"}}},
 			input: []string{
 				"import  MyLib   1.0",
 				"import OtherModule",
@@ -1562,9 +1631,9 @@ func TestFormatFirstPartyPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name:       "first-party imports are sorted and deduplicated within their group",
+			name:       "group imports are sorted and deduplicated within their section",
 			lineEnding: "\n",
-			options:    Options{FirstPartyPrefixes: []string{"io.github.mpvqc."}},
+			options:    Options{Groups: [][]string{{"io.github.mpvqc."}}},
 			input: []string{
 				"import QtQuick",
 				"import io.github.mpvqc.Charlie",

--- a/internal/qml/format_test.go
+++ b/internal/qml/format_test.go
@@ -1286,6 +1286,70 @@ func TestFormatErrors(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:       "import with non-ASCII module name returns an error",
+			lineEnding: "\n",
+			input: []string{
+				"import Café.Views",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			wantErr:         true,
+			wantErrContains: "invalid import name",
+		},
+		{
+			name:       "unrecognized line inside the import block returns an error",
+			lineEnding: "\n",
+			input: []string{
+				"import QtQuick",
+				"foo bar",
+				"import QtQml",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			wantErr:         true,
+			wantErrContains: "unrecognized line",
+		},
+		{
+			name:       "unterminated quoted path returns an error",
+			lineEnding: "\n",
+			input: []string{
+				`import "foo`,
+				"",
+				"Rectangle {",
+				"}",
+			},
+			wantErr:         true,
+			wantErrContains: "unterminated",
+		},
+		{
+			name:       "pragma keyword without a name returns an error",
+			lineEnding: "\n",
+			input: []string{
+				"pragma ",
+				"import QtQuick",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			wantErr:         true,
+			wantErrContains: "pragma without name",
+		},
+		{
+			name:       "import keyword without a name returns an error",
+			lineEnding: "\n",
+			input: []string{
+				"import ",
+				"import QtQuick",
+				"",
+				"Rectangle {",
+				"}",
+			},
+			wantErr:         true,
+			wantErrContains: "import without name",
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary

Replaces the single-purpose `--first-party-prefix` flag with a repeatable `--group` flag, so projects can split their imports into any number of custom sections instead of exactly one first-party bucket.

The output layout is a fixed frame around a configurable middle:

1. pragmas
2. Qt (`Qt[A-Z0-9.]…` names plus the `QML` base module)
3. default — everything no group claims
4. custom sections — one per `--group <prefix>[,<prefix>...]`, in flag order
5. relative (quoted paths)

Classification is independent of flag order: imports match by the longest prefix across all groups, Qt-owned namespaces (`Qt*`, `qt*`, `QML`, `QML.*`) are reserved and rejected as prefixes, and exact duplicate prefixes are compile errors while overlapping ones are now legal. With no `--group` flags the output is byte-identical to the previous default behavior; a single `--group` reproduces the old `--first-party-prefix` layout.

**Breaking change**: `--first-party-prefix` is removed without a compatibility shim (pre-1.0, per the new README stability note).

Also included:

- Design docs: minimal example-driven CLI contract in `docs/devel/CLI.md`, full classification/validation semantics plus the planned YAML/TOML config-file mapping in `docs/devel/INTERNAL_API.md`
- README rewritten around one source file formatted three different ways, with marker-driven `TestReadmeExamples` replaying every documented command through the real CLI so the examples can never drift
- `.gitignore` fix: anchor the built-binary pattern to `/qmlimportsort` — it previously swallowed the `cmd/qmlimportsort/` source directory

## Test plan

- [x] TDD: tests for the new API committed first (`1e5e699`), implementation after (`ccb2b0b`)
- [x] `just test` — full suite green (Compile validation, section placement, longest-match, flag order, comma grouping, CLI exit codes)
- [x] `TestReadmeExamples` — all three README examples verified against the real binary; drift check confirmed by corrupting an expected block and watching it fail
- [x] `go vet`, `staticcheck`, `gosec` clean
- [x] Manual smoke test of both `docs/devel/CLI.md` example commands — output matches byte-for-byte